### PR TITLE
Add build() method to ViewSkeletonScreen.Builder

### DIFF
--- a/library/src/main/java/com/ethanhua/skeleton/ViewSkeletonScreen.java
+++ b/library/src/main/java/com/ethanhua/skeleton/ViewSkeletonScreen.java
@@ -152,6 +152,10 @@ public class ViewSkeletonScreen implements SkeletonScreen {
             skeletonScreen.show();
             return skeletonScreen;
         }
+        
+        public ViewSkeletonScreen build() {
+            return new ViewSkeletonScreen(this);
+        }
 
     }
 }


### PR DESCRIPTION
Adds the ability for a ViewSkeletonScreen instance to be built without being shown immediately